### PR TITLE
Bugfixes and doc updates for v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/ttzhou/cldr.svg)](https://pkg.go.dev/github.com/ttzhou/cldr)
 ![go](https://img.shields.io/github/go-mod/go-version/ttzhou/cldr)
 [![codecov](https://codecov.io/gh/ttzhou/cldr/graph/badge.svg?token=SUU0ERUAST)](https://codecov.io/gh/ttzhou/cldr)
+[![ci-checks](https://github.com/ttzhou/cldr/actions/workflows/ci.yml/badge.svg)](https://github.com/ttzhou/cldr/actions/workflows/ci.yml)
 
 # about
 
@@ -43,7 +44,8 @@ func main() {
 
     mf.MustSetLocale("fr-CA")
 	fmt.Println(mf.MustFormat(f, uint64(w), amt.Curr().String())) // 91 411,21 $
-	fmt.Println(mf.MustFormat(f, uint64(w), "JPY")) // 91 411 ¥
+	// fmt.Println(mf.MustFormat(f, uint64(w), "JPY")) - panics
+	fmt.Println(mf.MustFormat(f, 0, "JPY")) // 91 411 ¥
 }
 ```
 

--- a/num/decimal.go
+++ b/num/decimal.go
@@ -51,7 +51,7 @@ func MustNewDecimalFormatter(l string) DecimalFormatter {
 // An error is returned if the scale is unsupported, i.e.
 // if it is <-1 or > the max supported scale = 20.
 func (df *DecimalFormatter) SetScale(s int8) error {
-	if s < -1 || int(s) > len(fracFormats)-1 {
+	if s < -1 || s > int8(maxSupportedScale) {
 		return unsupportedScaleError(s)
 	}
 
@@ -86,7 +86,7 @@ func (df DecimalFormatter) Format(w int64, f uint64) (string, error) {
 	return df.numberFormatter.format(w, f, df.scale, "")
 }
 
-// MustFormat calls [Format], and panics if there is an error.
+// MustFormat calls [DecimalFormatter.Format], and panics if there is an error.
 func (df DecimalFormatter) MustFormat(w int64, f uint64) string {
 	s, err := df.Format(w, f)
 	if err != nil {

--- a/test/num/decimal_test.go
+++ b/test/num/decimal_test.go
@@ -1,6 +1,7 @@
 package num_test
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -19,12 +20,17 @@ func TestDecimalFormatter(t *testing.T) {
 	t.Run("NewDecimalFormatter()", func(t *testing.T) {
 		t.Run("unsupported locales", func(t *testing.T) {
 			for i, tc := range []decimalTestCase{
-				{"xx", 1000000, 100, 1, ""},
-				{"en-XX", 1000000, 100, 1, ""},
+				{"xx", 1000000, 100, 1, "unsupported locale: \"xx\""},
+				{"en-XX", 1000000, 100, 1, "unsupported locale: \"en-XX\""},
 			} {
 				_, err := num.NewDecimalFormatter(tc.locale)
 				if err == nil {
 					t.Errorf("test case #%d - expected error but did not receive one", i+1)
+					continue
+				}
+				actual := err.Error()
+				if actual != tc.expected {
+					t.Errorf("test case #%d - got: %q, expected: %q", i+1, actual, tc.expected)
 				}
 			}
 		})
@@ -33,21 +39,27 @@ func TestDecimalFormatter(t *testing.T) {
 	t.Run("Format()", func(t *testing.T) {
 		t.Run("unsupported scale error", func(t *testing.T) {
 			for i, tc := range []decimalTestCase{
-				{"en", 1000000, 100, 21, ""},
-				{"en", 1000000, 100, -2, ""},
+				{"en", 1000000, 100, 21, "scale 21 exceeds max supported scale 20"},
+				{"en", 1000000, 100, -2, "scale -2 must be at least -1"},
 			} {
 				nf := num.MustNewDecimalFormatter(tc.locale)
 
 				err := nf.SetScale(tc.scale)
 				if err == nil {
 					t.Errorf("test case #%d - expected error but did not receive one", i+1)
+					continue
+				}
+				actual := err.Error()
+				if actual != tc.expected {
+					t.Errorf("test case #%d - got: %q, expected: %q", i+1, actual, tc.expected)
 				}
 			}
 		})
 		t.Run("fractional scale error", func(t *testing.T) {
 			for i, tc := range []decimalTestCase{
-				{"en", 1000000, 100, 1, ""},
-				{"en", 1000000, math.MaxUint64, 19, ""},
+				{"en", 1000000, 1, 0, "fractional part 1 exceeds scale 0"},
+				{"en", 1000000, 100, 1, "fractional part 100 exceeds scale 1"},
+				{"en", 1000000, math.MaxUint64, 19, fmt.Sprintf("fractional part %d exceeds scale 19", uint(math.MaxUint64))},
 			} {
 				nf := num.MustNewDecimalFormatter(tc.locale)
 				_ = nf.SetScale(tc.scale)
@@ -55,6 +67,11 @@ func TestDecimalFormatter(t *testing.T) {
 				_, err := nf.Format(tc.whole, tc.frac)
 				if err == nil {
 					t.Errorf("test case #%d - expected error but did not receive one", i+1)
+					continue
+				}
+				actual := err.Error()
+				if actual != tc.expected {
+					t.Errorf("test case #%d - got: %q, expected: %q", i+1, actual, tc.expected)
 				}
 			}
 		})
@@ -63,7 +80,6 @@ func TestDecimalFormatter(t *testing.T) {
 			for i, tc := range []decimalTestCase{
 				{"en", 1, 0, 0, "1"},
 				{"en", 1, 0, 2, "1.00"},
-				{"en", 1, 0o1, 0, "1"},
 				{"en", 1, 0o1, -1, "1.1"},
 				{"en", 1, 0o1, 1, "1.1"},
 				{"en", 1, 0o1, 2, "1.01"},


### PR DESCRIPTION
Didn't like that JPY just silently dropped the fractional part. We should error out. Caller should be responsible for ensuring the fractional part is correctly rounded so we don't make any assumptions. 

Also added example and `ci-checks` workflow badge to README.