### PR TITLE
Allow getting CLDR version used for data

### DIFF
--- a/internal/gen/write.go
+++ b/internal/gen/write.go
@@ -30,6 +30,8 @@ package locale
 
 import "strings"
 
+const CLDRVersion = "%s"
+
 func Get(l string) (Locale, bool) {
 	locale, ok := localeDataMap[strings.ReplaceAll(l, "_", "-")]
 	return locale, ok
@@ -194,6 +196,7 @@ func (c cldrData) writeLocaleFiles(localeDir, coverageLevel string) (int, int, e
 	location := filepath.Join(localeDir, "01_locales.go")
 	contentBytes := fmt.Appendf([]byte{},
 		localeVarFileTemplate,
+		cldrVersion,
 		coverageLevel,
 		localeMappings.String(),
 	)

--- a/internal/locale/01_locales.go
+++ b/internal/locale/01_locales.go
@@ -4,6 +4,8 @@ package locale
 
 import "strings"
 
+const CLDRVersion = "48.2.0"
+
 func Get(l string) (Locale, bool) {
 	locale, ok := localeDataMap[strings.ReplaceAll(l, "_", "-")]
 	return locale, ok

--- a/test/version/version_test.go
+++ b/test/version/version_test.go
@@ -1,0 +1,20 @@
+package version_test
+
+import (
+	"testing"
+
+	"github.com/ttzhou/cldr/internal/locale"
+	"github.com/ttzhou/cldr/version"
+)
+
+func Test(t *testing.T) {
+	usedForGen, usedForModule := locale.CLDRVersion, version.Get()
+
+	if usedForGen != usedForModule {
+		t.Errorf(
+			"module CLDR version %v does not match version used to generate CLDR data %v",
+			usedForModule,
+			usedForGen,
+		)
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,10 @@
+// Package version allows you to fetch the CLDR version used in data generation.
+package version
+
+import "github.com/ttzhou/cldr/internal/locale"
+
+// Get returns the CLDR revision used by this module for its various packages.
+// This can update at any point as the package evolves.
+func Get() string {
+	return locale.CLDRVersion
+}


### PR DESCRIPTION
Adds a package + method that exposes the CLDR version used to generate all the underlying locale data.